### PR TITLE
feat: Add --filter options to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ env.yaml auto generate CLI tool for Google AppEngine.
 
 When deploying applications to Google AppEngine, we bother us with managing environment variables.
 
-This package automatically generates a dedicated YAML file that enumerates environment variables (with the prefix you specified) and makes managing environment variables the easiest.
+This package automatically generates a dedicated YAML file that enumerates environment variables (with the prefix and regex filter you specified) and makes managing environment variables the easiest.
 
 ## Usage
 
@@ -29,7 +29,7 @@ includes:
 $ yarn add @elevenback/env-yaml-generator -D
 $ export DEV_API_ROOT="https://dev.example.com"
 $ export PROD_API_ROOT="https://prod.example.com"
-$ yarn create-env-yaml --environment DEV
+$ yarn create-env-yaml --environment DEV --filter "API_.+"
 $ cat ./env.yaml
 env_variables:
   API_ROOT: "https://dev.example.com"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,12 +9,17 @@ const CLI = meow(
 
   Options
     --environment, -E prefix for target env vars name (default is "DEV_")
+    --filter, -F regex filter for target env vars name (optional)
 `,
   {
     flags: {
       environment: {
         type: 'string',
         alias: 'E'
+      },
+      filter: {
+        type: 'string',
+        alias: 'F'
       }
     }
   }

--- a/src/core.spec.ts
+++ b/src/core.spec.ts
@@ -5,12 +5,14 @@ describe('src/core.ts', () => {
     it('returns correct string', () => {
       const processEnvMock = {
         DEV_API_ROOT: 'https://dev.example.com',
-        PROD_API_ROOT: 'https://prod.example.com'
+        PROD_API_ROOT: 'https://prod.example.com',
+        DEV_OTHERSERVICE_ROOT: 'https://dev.other.example.com',
+        PROD_OTHERSERVICE_ROOT: 'https://prod.other.example.com'
       }
       const expectYaml = `env_variables:
   API_ROOT: https://dev.example.com
 `
-      expect(core.createYAML(processEnvMock, 'DEV')).toBe(expectYaml)
+      expect(core.createYAML(processEnvMock, 'DEV', 'API_.+')).toBe(expectYaml)
     })
   })
 })

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -14,6 +14,20 @@ describe('src/env.ts', () => {
       })
     })
   })
+  describe('.getFilteredEnvironments', () => {
+    describe("when given 'API'", () => {
+      it('returns only API related environments', () => {
+        const processEnvMock = {
+          API_KEY: 'https://prod.example.com',
+          OTHERSERVICE_KEY: 'OTHERSERVICE_VALUE',
+          API2_KEY: 'https://prod2.example.com'
+        }
+        expect(env.getFilteredEnvironments(processEnvMock, 'API_.+')).toEqual({
+          API_KEY: 'https://prod.example.com'
+        })
+      })
+    })
+  })
   describe('.convertAppEngineStyleYamlFromEnvironments', () => {
     it('returns wrapped environments', () => {
       const environments = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -25,6 +25,16 @@ export function getTargetEnvironments(
     }, {})
 }
 
+export function getFilteredEnvironments(
+  environments: Environments,
+  filter: string
+): Environments {
+  const regex = new RegExp(filter)
+  return Object.fromEntries(
+    Object.entries(environments).filter(([k, v]) => regex.exec(k))
+  )
+}
+
 export function convertAppEngineStyleYamlFromEnvironments(
   environments: Environments
 ): { env_variables: Environments } {

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,9 +30,14 @@ export function getFilteredEnvironments(
   filter: string
 ): Environments {
   const regex = new RegExp(filter)
-  return Object.fromEntries(
-    Object.entries(environments).filter(([k, v]) => regex.exec(k))
-  )
+  return Object.entries(environments)
+    .filter(([k, v]) => regex.exec(k))
+    .reduce((before, after) => {
+      return {
+        ...before,
+        [after[0]]: after[1]
+      }
+    }, {})
 }
 
 export function convertAppEngineStyleYamlFromEnvironments(


### PR DESCRIPTION
Resolves: #4 

# 概要
- CLI に `--filter` (`-F`) 引数を追加します。
  - 引数に渡された値は正規表現として処理され、`--environment` によって処理されたあとの配列から合致する値のみを抽出します。
- `env.ts` に 関数 `getFilteredEnvironments` を追加します。
  - `environments` と `filter` を引数として受け取り、`environments` のうち `filter` を正規表現として扱ったときに当てはまる組のみを返却します。

# 注意点
- RegExp の exec で問題ないか
- フィルタリング関数を `getFilteredEnvironments` に分離してしまう形にしたが問題ないか
- フィルタを複数受け付けるわけではないと思い原案 `filters` を `fitler` にして実装しているが問題ないか
- ~~コマンドラインで正しく RegExp を受け取れるか~~ 受け取れることを確認しました
- テストケースが不合致ではないか/テストが不足していないか