### PR TITLE
fix: optional --environment

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ const CLI = meow(
     $ create-env-yaml
 
   Options
-    --environment, -E prefix for target env vars name (default is "DEV_")
+    --environment, -E prefix for target env vars name (optional)
     --filter, -F regex filter for target env vars name (optional)
 `,
   {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,8 @@
 import {
   getTargetEnvironments,
   convertAppEngineStyleYamlFromEnvironments,
-  getFilteredEnvironments
+  getFilteredEnvironments,
+  Environments
 } from './env'
 import { promisify } from 'util'
 import * as YAML from 'yaml'
@@ -11,10 +12,13 @@ const writeFile = promisify(fs.writeFile)
 
 export function createYAML(
   processEnv: NodeJS.ProcessEnv,
-  environment: string,
+  environment?: string,
   filter?: string
 ): string {
-  let environments = getTargetEnvironments(processEnv, environment)
+  let environments = processEnv as Environments
+  if (environment) {
+    environments = getTargetEnvironments(processEnv, environment)
+  }
   if (filter) {
     environments = getFilteredEnvironments(environments, filter)
   }
@@ -25,7 +29,7 @@ export function createYAML(
 }
 
 export async function exec(flags: Result['flags']) {
-  const environment = (flags.environment as string | undefined) || 'DEV'
+  const environment = flags.environment as string | undefined
   const filter = flags.filter as string | undefined
   const yamlData = createYAML(process.env, environment, filter)
   try {

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,7 @@ export function createYAML(
 ): string {
   let environments = processEnv as Environments
   if (environment) {
-    environments = getTargetEnvironments(processEnv, environment)
+    environments = getTargetEnvironments(environments, environment)
   }
   if (filter) {
     environments = getFilteredEnvironments(environments, filter)

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -19,10 +19,10 @@ describe('src/env.ts', () => {
       it('returns only API related environments', () => {
         const processEnvMock = {
           API_KEY: 'https://prod.example.com',
-          OTHERSERVICE_KEY: 'OTHERSERVICE_VALUE',
+          OTHERSERVICE_API_KEY: 'OTHERSERVICE_VALUE',
           API2_KEY: 'https://prod2.example.com'
         }
-        expect(env.getFilteredEnvironments(processEnvMock, 'API_.+')).toEqual({
+        expect(env.getFilteredEnvironments(processEnvMock, '^API_.+')).toEqual({
           API_KEY: 'https://prod.example.com'
         })
       })

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,7 +10,7 @@ export function getTargetEnvironments(
 ): Environments {
   return Object.entries(environments)
     .filter(([k, v]: KeyValuePairs) => {
-      return k.includes(`${prefix}_`)
+      return k.startsWith(`${prefix}_`)
     })
     .map(
       ([k, v]: KeyValuePairs): KeyValuePairs => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,14 +1,14 @@
-type Environments = NodeJS.ProcessEnv & {
+export type Environments = NodeJS.ProcessEnv & {
   [key: string]: string | undefined
 }
 
 type KeyValuePairs = [string, string | undefined]
 
 export function getTargetEnvironments(
-  processEnv: NodeJS.ProcessEnv,
+  environments: Environments,
   prefix: string
 ): Environments {
-  return Object.entries(processEnv)
+  return Object.entries(environments)
     .filter(([k, v]: KeyValuePairs) => {
       return k.includes(`${prefix}_`)
     })


### PR DESCRIPTION
Resolves: #7 

# 概要
- 今までは無指定の場合自動で `DEV` が env prefix として採用されていたが、何も絞り込まないようになった。
  - `filter` なども用いない場合シェルに設定された環境変数がズラッと書き出されてしまうので注意すること。


# 注意点
- `getTargetEnvironments` などの概念はあまり触らないまま引数をそもそも ObjectLiteral (Environments) で受け取るようにし、関数としては `getFilteredEnvironments` と並べる形としたが問題ないか。
- 実はキーのみ配列で処理していって値を合わせるのは取りたいキーの一覧が出てからでいいのかもしれない。
- これは前からも同じだが、 `API_ROOT` と `HOGEPIYO_API_KEY` などが並んでいた場合、`filter` にきちんと `^API_.+` のようにしてやらないと後者まで取り込まれる。
